### PR TITLE
Fix hidden headlines covering links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="{{ site.url }}/css/hellothisistim.css">
 <meta name="description" content="{{ site.description }}">
 
-<!-- v2.2.0 -->
+<!-- v2.2.1 -->
   
 <link rel="apple-touch-icon" sizes="57x57" href="http://hellothisistim.com/favicon/apple-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="http://hellothisistim.com/favicon/apple-icon-60x60.png">

--- a/css/hellothisistim.css
+++ b/css/hellothisistim.css
@@ -134,7 +134,8 @@ nav > h2,
 #legal >h2 {
     position: absolute;
     text-indent: -9999px;
-    text-align: left;    
+    text-align: left;
+    width: 0px; /* Avoids hidden text headlines from blocking links. */
 }
 
 /* -------------------------------------------------------------------


### PR DESCRIPTION
Finally figured out why the Twitter link wasn't working in the social media section. The headline, which had been moved off-screen was still drawing a box that was blocking the click area for the Twitter link.